### PR TITLE
Remove jdom2-contrib from PGM dependencies

### DIFF
--- a/PGM/pom.xml
+++ b/PGM/pom.xml
@@ -22,12 +22,6 @@
             <version>2.0.5</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.jdom</groupId>
-            <artifactId>jdom2-contrib</artifactId>
-            <version>2.0.5</version>
-        </dependency>
-
 
         <!-- Our stuff -->
 


### PR DESCRIPTION
jdom2-contrib can't be found in any of the repositories and PGM builds fine without it.
jdom2 is still a dependency.