### PR TITLE
Added .travis.yml for automated tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: java
+dist: trusty #Older versions don't provide openjdk8
+jdk:
+    - openjdk8
+    - oraclejdk8
+script: mvn test -B


### PR DESCRIPTION
This commit allows running automated tests on this repository using travis-ci.org (Free for open source projects)

In addition to accepting this PR someone with admin access to this repository has to log in to travis using his GitHub account and enable automated builds for this repo.

EDIT: I just noticed that you are already doing builds using Jenkins, but adding this would still be a good idea, as 

1. The result displays right next to the commit on github
2. It automatically tests PRs
3. It's easy for forks to set it up
4. It can test with multiple java versions (in this case openjdk8 and oraclejdk8)