### PR TITLE
Rename Raindrop(s) to Droplet(s)

### DIFF
--- a/Commons/core/src/main/i18n/templates/commons/Commons.properties
+++ b/Commons/core/src/main/i18n/templates/commons/Commons.properties
@@ -183,8 +183,8 @@ entity.ThrownEnderpearl.name = Ender Pearl
 # {2} = "raindrop/raindrops"
 raindrops.balance.self = You have {1} {2}
 raindrops.balance.other = {0} has {1} {2}
-raindrops.singular = raindrop
-raindrops.plural = raindrops
+raindrops.singular = droplet
+raindrops.plural = droplets
 
 material.Iron = Iron
 material.gold = Gold

--- a/Commons/core/src/main/i18n/templates/lobby/LobbyErrors.properties
+++ b/Commons/core/src/main/i18n/templates/lobby/LobbyErrors.properties
@@ -1,5 +1,5 @@
-gizmo.gun.empty = No Raindrops available to shoot
+gizmo.gun.empty = No Droplets available to shoot
 
-raindrops.purchase.fail = You do not have enough Raindrops to purchase this
+raindrops.purchase.fail = You do not have enough Droplets to purchase this
 
 purchase.purchase.fail = Purchase failed

--- a/Commons/core/src/main/i18n/templates/lobby/LobbyMessages.properties
+++ b/Commons/core/src/main/i18n/templates/lobby/LobbyMessages.properties
@@ -7,8 +7,8 @@ gizmo.popper.description = Clear players with a satisfying pop
 gizmo.rocket.name = Player Rocketer
 gizmo.rocket.description = Hide players by launching them into colorful fireworks
 
-gizmo.gun.name = Raindrop Gun
-gizmo.gun.description = Gift raindrops with a punch :D
+gizmo.gun.name = Droplet Gun
+gizmo.gun.description = Gift droplets with a punch :D
 
 gizmo.chicken.name = Chickenifier5000
 gizmo.chicken.description = bok B'GAWK
@@ -17,7 +17,7 @@ gizmo.chicken.description = bok B'GAWK
 # {0} = number of players chickened
 gizmo.chicken.raindropsResult = chicken'd a total of {0} players
 
-gizmo.gun.raindropsResult = raindrop gun gift
+gizmo.gun.raindropsResult = droplet gun gift
 
 # {0} = number of players popped
 gizmo.popper.raindropsResult = popped a total of {0} players

--- a/Commons/core/src/main/i18n/templates/lobby/LobbyUI.properties
+++ b/Commons/core/src/main/i18n/templates/lobby/LobbyUI.properties
@@ -4,10 +4,10 @@ gizmo.current = Current gizmo: {0}
 gizmo.purchasing = Purchasing...
 gizmo.purchasing.cancel = Purchase cancelled
 gizmo.purchased = Purchased
-gizmo.purchased.success = Purchased {0} for {1} raindrops
+gizmo.purchased.success = Purchased {0} for {1} droplets
 
 # {0} The cost in raindrops of the gizmo
-gizmo.cost = {0} Raindrops
+gizmo.cost = {0} Droplets
 
 # {0} the colored name of the gizmo that was equipped
 gizmo.equip = Gizmo equipped: {0}


### PR DESCRIPTION
Rename Raindrop(s) to Droplet(s), internally they are still referred to as Raindrops.