### PR TITLE
Fix edge case errors with mutations

### DIFF
--- a/Commons/core/src/main/i18n/templates/pgm/PGMMessages.properties
+++ b/Commons/core/src/main/i18n/templates/pgm/PGMMessages.properties
@@ -198,6 +198,7 @@ mutation.type.explosive = Explosive
 mutation.type.explosive.desc = tnt and fire bows
 mutation.type.elytra = Elytra
 mutation.type.elytra.desc = fly around with an elytra
+mutation.type.elytra.land = Land immediately. Your elytra is being grounded in {0} seconds.
 mutation.type.projectile = Projectile
 mutation.type.projectile.desc = arrow potion effects
 mutation.type.enchantment = Enchantment
@@ -267,6 +268,9 @@ lives.remaining.individual.singular = You have {0} life left
 lives.remaining.individual.plural = You have {0} lives left
 lives.remaining.team.singular = Your team has {0} life left
 lives.remaining.team.plural = Your team has {0} lives left
+
+lives.remaining.alive.singular = Your team has {0} player left
+lives.remaining.alive.plural = Your team has {0} players left
 
 lives.status.eliminated = eliminated
 lives.status.alive = {0} alive

--- a/PGM/src/main/java/tc/oc/pgm/blitz/LivesBase.java
+++ b/PGM/src/main/java/tc/oc/pgm/blitz/LivesBase.java
@@ -27,7 +27,7 @@ public abstract class LivesBase implements Lives {
         update();
     }
 
-    private void update() {
+    protected void update() {
         competitor().getMatch().callEvent(new LivesEvent(this));
     }
 
@@ -67,7 +67,8 @@ public abstract class LivesBase implements Lives {
     public BaseComponent remaining() {
         return new Component(
             new TranslatableComponent(
-                "lives.remaining." + type().name().toLowerCase() + "." + (current() == 1 ? "singular" : "plural"),
+                "lives.remaining." + type().name().toLowerCase() + "." + (current() == 1 ? "singular"
+                                                                                         : "plural"),
                 new Component(current(), ChatColor.YELLOW)
             ),
             ChatColor.AQUA
@@ -103,7 +104,7 @@ public abstract class LivesBase implements Lives {
             new TranslatableComponent(
                 (delta > 0 ? "lives.change.gained."
                            : "lives.change.lost.") + (absDelta == 1 ? "singular"
-                                                                           : "plural"),
+                                                                    : "plural"),
                 new Component(absDelta, ChatColor.AQUA)
             ),
             ChatColor.WHITE

--- a/PGM/src/main/java/tc/oc/pgm/blitz/LivesTeam.java
+++ b/PGM/src/main/java/tc/oc/pgm/blitz/LivesTeam.java
@@ -1,6 +1,11 @@
 package tc.oc.pgm.blitz;
 
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.TranslatableComponent;
 import tc.oc.api.docs.PlayerId;
+import tc.oc.commons.core.chat.Component;
+import tc.oc.commons.core.chat.Components;
 import tc.oc.pgm.match.Competitor;
 
 public class LivesTeam extends LivesBase {
@@ -22,6 +27,24 @@ public class LivesTeam extends LivesBase {
     @Override
     public boolean owner(PlayerId playerId) {
         return false;
+    }
+
+    public int alive() {
+        return (int) competitor().participants().count();
+    }
+
+    @Override
+    public BaseComponent remaining() {
+        int alive = alive() - 1;
+        if(alive == 0) return Components.blank();
+        return empty() ? new Component(
+            new TranslatableComponent(
+                "lives.remaining.alive." + (alive == 1 ? "singular"
+                                                       : "plural"),
+                new Component(alive, ChatColor.YELLOW)
+            ),
+            ChatColor.AQUA
+        ) : super.remaining();
     }
 
     @Override

--- a/PGM/src/main/java/tc/oc/pgm/modules/MobsMatchModule.java
+++ b/PGM/src/main/java/tc/oc/pgm/modules/MobsMatchModule.java
@@ -1,6 +1,7 @@
 package tc.oc.pgm.modules;
 
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import tc.oc.pgm.events.ListenerScope;
@@ -9,7 +10,6 @@ import tc.oc.pgm.filters.Filter;
 import tc.oc.pgm.filters.query.EntitySpawnQuery;
 import tc.oc.pgm.match.MatchModule;
 import tc.oc.pgm.match.MatchScope;
-import tc.oc.pgm.mutation.MutationMatchModule;
 
 @ListenerScope(MatchScope.LOADED)
 public class MobsMatchModule extends MatchModule implements Listener {
@@ -37,10 +37,9 @@ public class MobsMatchModule extends MatchModule implements Listener {
         getMatch().getWorld().setSpawnFlags(false, false);
     }
 
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
     public void checkSpawn(final CreatureSpawnEvent event) {
-        if(!match.module(MutationMatchModule.class).map(mmm -> mmm.allowMob(event.getSpawnReason())).orElse(false) &&
-           event.getSpawnReason() != CreatureSpawnEvent.SpawnReason.CUSTOM) {
+        if(event.getSpawnReason() != CreatureSpawnEvent.SpawnReason.CUSTOM) {
             event.setCancelled(mobsFilter.query(new EntitySpawnQuery(event, event.getEntity(), event.getSpawnReason())).isDenied());
         }
     }

--- a/PGM/src/main/java/tc/oc/pgm/mutation/MutationMatchModule.java
+++ b/PGM/src/main/java/tc/oc/pgm/mutation/MutationMatchModule.java
@@ -4,7 +4,6 @@ import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import org.bukkit.event.entity.CreatureSpawnEvent;
 import tc.oc.commons.core.util.MapUtils;
 import tc.oc.commons.core.random.RandomUtils;
 import tc.oc.pgm.Config;
@@ -155,19 +154,6 @@ public class MutationMatchModule extends MatchModule {
 
     public boolean enabled(Mutation... mutations) {
         return mutationsActive().stream().anyMatch(m1 -> Stream.of(mutations).anyMatch(m2 -> m2.equals(m1)));
-    }
-
-    public boolean allowMob(CreatureSpawnEvent.SpawnReason reason) {
-        switch(reason) {
-            case NATURAL:
-            case DEFAULT:
-            case CHUNK_GEN:
-            case JOCKEY:
-            case MOUNT:
-                return false;
-            default:
-                return true;
-        }
     }
 
 }

--- a/PGM/src/main/java/tc/oc/pgm/mutation/types/EntityMutation.java
+++ b/PGM/src/main/java/tc/oc/pgm/mutation/types/EntityMutation.java
@@ -1,0 +1,239 @@
+package tc.oc.pgm.mutation.types;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.reflect.TypeToken;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.bukkit.event.player.PlayerSpawnEntityEvent;
+import org.bukkit.inventory.EntityEquipment;
+import tc.oc.commons.core.collection.WeakHashSet;
+import tc.oc.pgm.events.MatchPlayerDeathEvent;
+import tc.oc.pgm.events.PlayerChangePartyEvent;
+import tc.oc.pgm.match.Match;
+import tc.oc.pgm.match.MatchPlayer;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.stream.Stream;
+
+import static tc.oc.commons.core.util.Optionals.cast;
+
+/**
+ * A mutation module that tracks entity spawns.
+ */
+public class EntityMutation<E extends Entity> extends KitMutation {
+
+    final Set<E> entities;
+    final Map<Instant, Set<E>> entitiesByTime;
+    final Map<MatchPlayer, Set<E>> entitiesByPlayer;
+    final Map<E, MatchPlayer> playersByEntity;
+
+    public EntityMutation(Match match, boolean force) {
+        super(match, force);
+        this.entities = new WeakHashSet<>();
+        this.entitiesByTime = new WeakHashMap<>();
+        this.entitiesByPlayer = new WeakHashMap<>();
+        this.playersByEntity = new WeakHashMap<>();
+    }
+
+    /**
+     * Gets an immutable stream of all registered entities.
+     * @return stream of entities.
+     */
+    public Stream<E> entities() {
+        return ImmutableSet.copyOf(entities).stream();
+    }
+
+    /**
+     * Gets an immutable stream of all registered entities
+     * by the time they spawned in ascending order.
+     * @return stream of entities.
+     */
+    public Stream<E> entitiesByTime() {
+        return ImmutableMap.copyOf(entitiesByTime)
+                           .entrySet()
+                           .stream()
+                           .sorted(Map.Entry.comparingByKey(Comparator.comparing(Instant::toEpochMilli)))
+                           .flatMap(entry -> ImmutableSet.copyOf(entry.getValue()).stream());
+    }
+
+    /**
+     * Gets an immutable stream of all registered entities
+     * that are owned by a player.
+     *
+     * If the given player is null, this will return entities
+     * with no owner.
+     * @param player the optional player.
+     * @return stream of entities.
+     */
+    public Stream<E> entitiesByPlayer(@Nullable MatchPlayer player) {
+        return ImmutableSet.copyOf(entitiesByPlayer.getOrDefault(player, new HashSet<>())).stream();
+    }
+
+    /**
+     * Gets the optional owner of an entity.
+     * @param entity the entity to find the owner of.
+     * @return the optional player.
+     */
+    public Optional<MatchPlayer> playerByEntity(Entity entity) {
+        return Optional.ofNullable(playersByEntity.get(entity));
+    }
+
+    /**
+     * Are entities with this spawn reason allowed to spawn?
+     * @param reason the spawn reason.
+     * @return whether this reason is allowed.
+     */
+    public boolean allowed(CreatureSpawnEvent.SpawnReason reason) {
+        switch(reason) {
+            case NATURAL:
+            case DEFAULT:
+            case CHUNK_GEN:
+            case JOCKEY:
+            case MOUNT:
+                return false;
+            default:
+                return true;
+        }
+    }
+
+    /**
+     * Register a new spawned entity with an optional owner.
+     * @param entity the entity to register.
+     * @param owner the optional owner.
+     * @return the entity.
+     */
+    public E register(E entity, @Nullable MatchPlayer owner) {
+        entities.add(entity);
+        final Instant now = match().getInstantNow();
+        final Set<E> byTime = entitiesByTime.getOrDefault(now, new WeakHashSet<>());
+        byTime.add(entity);
+        entitiesByTime.put(now, byTime);
+        if(owner != null) {
+            final Set<E> byPlayer = entitiesByPlayer.getOrDefault(owner, new WeakHashSet<>());
+            byPlayer.add(entity);
+            entitiesByPlayer.put(owner, byPlayer);
+            playersByEntity.put(entity, owner);
+        }
+        return entity;
+    }
+
+    /**
+     * Removes the entity from the world.
+     *
+     * Typically this should be {@link Entity#remove()},
+     * but it can also expire the entity after a couple of seconds.
+     * @param entity the entity to remove.
+     */
+    public void remove(E entity) {
+        entity.remove();
+    }
+
+    /**
+     * Unregister and remove the given entity.
+     * @param entity the entity.
+     */
+    public void despawn(E entity) {
+        entities.remove(entity);
+        playersByEntity.remove(entity);
+        Stream.of(entitiesByTime, entitiesByPlayer)
+              .flatMap(map -> ImmutableList.copyOf(map.values()).stream())
+              .forEach(set -> set.remove(entity));
+        remove(entity);
+    }
+
+    /**
+     * Unregister and remove any entities owned by the given player.
+     * @param player the owner of the entities.
+     */
+    public void despawn(MatchPlayer player) {
+        ImmutableSet.copyOf(entitiesByPlayer.getOrDefault(player, new HashSet<>())).forEach(this::despawn);
+    }
+
+    /**
+     * Spawn an entity at the given location with no owner.
+     * @see #spawn(Location, Class, MatchPlayer)
+     * @return the entity.
+     */
+    public E spawn(Location location, Class<E> entityClass) {
+        return spawn(location, entityClass, null);
+    }
+
+    /**
+     * Spawn an entity at the given location.
+     * @param location the location to spawn the entity.
+     * @param entityClass the class of the entity.
+     * @param owner the optional owner of the entity.
+     * @return the entity.
+     */
+    public E spawn(Location location, Class<E> entityClass, @Nullable MatchPlayer owner) {
+        E entity = world().spawn(location, entityClass);
+        cast(entity, LivingEntity.class).ifPresent(living -> {
+            living.setCanPickupItems(false);
+            living.setRemoveWhenFarAway(true);
+            EntityEquipment equipment = living.getEquipment();
+            equipment.setHelmetDropChance(0);
+            equipment.setChestplateDropChance(0);
+            equipment.setLeggingsDropChance(0);
+            equipment.setBootsDropChance(0);
+        });
+        return register(entity, owner);
+    }
+
+    @EventHandler(ignoreCancelled = false, priority = EventPriority.HIGHEST)
+    public void onPlayerSpawnEntity(PlayerSpawnEntityEvent event) {
+        match().participant(event.getPlayer())
+               .ifPresent(player -> cast(event.getEntity(), new TypeToken<E>(){}.getRawType())
+               .ifPresent(entity -> {
+                   register((E) entity, player);
+                   event.setCancelled(false);
+               }));
+    }
+
+    @EventHandler(ignoreCancelled = false, priority = EventPriority.HIGHEST)
+    public void onEntitySpawn(CreatureSpawnEvent event) {
+        boolean allowed = allowed(event.getSpawnReason());
+        event.setCancelled(!allowed);
+        if(allowed) {
+            cast(event.getEntity(), new TypeToken<E>(){}.getRawType())
+                      .filter(entity -> !playerByEntity((E) entity).isPresent())
+                      .ifPresent(entity -> register((E) entity, null));
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
+    public void onPlayerDeath(MatchPlayerDeathEvent event) {
+        despawn(event.getVictim());
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
+    public void onPartyChange(PlayerChangePartyEvent event) {
+        despawn(event.getPlayer());
+    }
+
+    @Override
+    public void remove(MatchPlayer player) {
+        despawn(player);
+        super.remove(player);
+    }
+
+    @Override
+    public void disable() {
+        entities().forEach(this::despawn);
+        Stream.of(entitiesByTime, entitiesByPlayer, playersByEntity).forEach(Map::clear);
+        super.disable();
+    }
+
+}

--- a/PGM/src/main/java/tc/oc/pgm/mutation/types/MutationModule.java
+++ b/PGM/src/main/java/tc/oc/pgm/mutation/types/MutationModule.java
@@ -1,12 +1,8 @@
 package tc.oc.pgm.mutation.types;
 
-import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.Listener;
-import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.ItemStack;
 import tc.oc.commons.bukkit.item.ItemBuilder;
 import tc.oc.commons.core.random.AdvancingEntropy;
@@ -15,7 +11,6 @@ import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.match.Match;
 import tc.oc.pgm.match.MatchScope;
 import tc.oc.pgm.mutation.Mutation;
-import tc.oc.pgm.mutation.MutationMatchModule;
 
 import java.util.Random;
 
@@ -28,69 +23,59 @@ import java.util.Random;
  * of breaking the match state.
  */
 @ListenerScope(MatchScope.RUNNING)
-public abstract class MutationModule implements Listener {
+public interface MutationModule extends Listener {
 
-    protected final Match match;
-    protected final World world;
-    protected final Entropy entropy;
-    protected final Random random;
+    Match match();
 
-    /**
-     * Constructed when {@link MutationMatchModule#load()}
-     * has been called. This will only be constructed if its
-     * subsequent {@link Mutation} is enabled for the match.
-     *
-     * @param match the match for this module.
-     */
-    public MutationModule(Match match) {
-        this.match = match;
-        this.world = match.getWorld();
-        this.entropy = new AdvancingEntropy();
-        this.random = new Random();
+    default void enable() {
+        match().registerEventsAndRepeatables(this);
     }
 
-    /**
-     * Called when the match starts.
-     *
-     * However, this should be able to be called at any
-     * point before the match ends and still work as expected.
-     */
-    public void enable() {
-        match.registerEventsAndRepeatables(this);
+    default void disable() {
+        match().unregisterEvents(this);
+        match().unregisterRepeatable(this);
     }
 
-    /**
-     * Called when the match ends.
-     *
-     * However, this should be able to be called at any
-     * point during a match and still work as expected.
-     */
-    public void disable() {
-        match.unregisterEvents(this);
-        match.unregisterRepeatable(this);
+    default World world() {
+        return match().getWorld();
     }
 
-    protected static ItemStack item(Material material, int amount) {
-        return new ItemBuilder().material(material).amount(amount).unbreakable(true).shareable(false).get();
+    default Entropy entropy() {
+        return match().entropyForTick();
     }
 
-    protected static ItemStack item(Material material) {
-        return item(material, 1);
+    default Random random() {
+        return match().getRandom();
     }
 
-    protected <E extends Entity> E spawn(Location location, Class<E> entityClass) {
-        E entity = world.spawn(location, entityClass);
-        if(entity instanceof LivingEntity) {
-            LivingEntity living = (LivingEntity) entity;
-            living.setCanPickupItems(false);
-            living.setRemoveWhenFarAway(true);
-            EntityEquipment equipment = living.getEquipment();
-            equipment.setHelmetDropChance(0);
-            equipment.setChestplateDropChance(0);
-            equipment.setLeggingsDropChance(0);
-            equipment.setBootsDropChance(0);
+    abstract class Impl implements MutationModule {
+
+        private final Match match;
+        private final Entropy entropy;
+
+        public Impl(final Match match) {
+            this.match = match;
+            this.entropy = new AdvancingEntropy(match.entropyForTick().randomLong());
         }
-        return entity;
+
+        @Override
+        public Match match() {
+            return match;
+        }
+
+        @Override
+        public Entropy entropy() {
+            return entropy;
+        }
+
+        protected static ItemStack item(Material material, int amount) {
+            return new ItemBuilder().material(material).amount(amount).unbreakable(true).shareable(false).get();
+        }
+
+        protected static ItemStack item(Material material) {
+            return item(material, 1);
+        }
+
     }
 
 }

--- a/PGM/src/main/java/tc/oc/pgm/mutation/types/TargetMutation.java
+++ b/PGM/src/main/java/tc/oc/pgm/mutation/types/TargetMutation.java
@@ -1,64 +1,114 @@
 package tc.oc.pgm.mutation.types;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 
-import tc.oc.commons.core.scheduler.Task;
 import tc.oc.commons.core.stream.Collectors;
+import tc.oc.commons.core.util.TimeUtils;
 import tc.oc.pgm.match.Match;
 import tc.oc.pgm.match.MatchPlayer;
-import tc.oc.pgm.match.MatchScope;
+import tc.oc.pgm.match.Repeatable;
+import tc.oc.time.Time;
 
 /**
  * A mutation module that executes a task on random {@link MatchPlayer}s.
  */
-public abstract class TargetMutation extends MutationModule {
-
-    private final Duration frequency;
-    private Task task;
-
-    public TargetMutation(final Match match, Duration frequency) {
-        super(match);
-        this.frequency = frequency;
-    }
+public interface TargetMutation extends MutationModule {
 
     /**
      * Execute a task on the given randomly selected players.
      * @param players a list of players, which size is determined by {@link #targets()}.
      */
-    public abstract void execute(List<MatchPlayer> players);
+    void target(List<MatchPlayer> players);
 
     /**
      * Determine the number of random players to target.
+     *
      * If there are no enough players on the server, it is possible
      * that the number of targets is less than expected.
      * @return number of targets.
      */
-    public abstract int targets();
+    int targets();
+
+    /**
+     * Get the next time {@link #target()} will be run.
+     * @return next target time.
+     */
+    Instant next();
+
+    /**
+     * Set the next time {@link #target()} will be run.
+     * @param time next target time.
+     */
+    void next(Instant time);
+
+    /**
+     * Get the frequency that {@link #target()} will be run.
+     * @return frequency between target times.
+     */
+    Duration frequency();
 
     /**
      * Generate a list of random players.
      * @return the random players.
      */
-    public List<MatchPlayer> search() {
-        return match.participants()
-                    .filter(MatchPlayer::isSpawned)
-                    .collect(Collectors.toRandomSubList(entropy, targets()));
+    default List<MatchPlayer> search() {
+        return match().participants()
+                      .filter(MatchPlayer::isSpawned)
+                      .collect(Collectors.toRandomSubList(entropy(), targets()));
+    }
+
+    /**
+     * Execute a task on randomly selected players and reset the
+     * next time the task will be executed.
+     */
+    default void target() {
+        target(search());
+        next(match().getInstantNow().plus(frequency()));
     }
 
     @Override
-    public void enable() {
-        super.enable();
-        this.task = match.getScheduler(MatchScope.RUNNING).createRepeatingTask(frequency, () -> execute(search()));
+    default void enable() {
+        MutationModule.super.enable();
+        target();
     }
 
-    @Override
-    public void disable() {
-        if(task != null) {
-            task.cancel();
-            task = null;
+    @Repeatable(interval = @Time(seconds = 1))
+    default void tick() {
+        Instant now = match().getInstantNow(), next = next();
+        if(next == null) {
+            next(now.plus(frequency()));
+        } else if(TimeUtils.isEqualOrBeforeNow(now, next)) {
+            target();
         }
-        super.disable();
+    }
+
+    abstract class Impl extends MutationModule.Impl implements TargetMutation {
+
+        Duration frequency;
+        Instant next;
+
+        public Impl(Match match, Duration frequency) {
+            super(match);
+            this.frequency = frequency;
+        }
+
+        @Override
+        public Instant next() {
+            return next;
+        }
+
+        @Override
+        public void next(Instant time) {
+            next = time;
+        }
+
+        @Override
+        public Duration frequency() {
+            return frequency;
+        }
+
     }
 
 }

--- a/PGM/src/main/java/tc/oc/pgm/mutation/types/kit/ElytraMutation.java
+++ b/PGM/src/main/java/tc/oc/pgm/mutation/types/kit/ElytraMutation.java
@@ -1,17 +1,31 @@
 package tc.oc.pgm.mutation.types.kit;
 
+import com.google.common.collect.ImmutableSet;
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Material;
+import tc.oc.commons.bukkit.chat.WarningComponent;
 import tc.oc.commons.bukkit.inventory.ArmorType;
 import tc.oc.commons.bukkit.inventory.Slot;
+import tc.oc.commons.core.chat.Component;
+import tc.oc.commons.core.chat.Components;
+import tc.oc.commons.core.collection.WeakHashSet;
+import tc.oc.commons.core.util.TimeUtils;
 import tc.oc.pgm.doublejump.DoubleJumpKit;
 import tc.oc.pgm.kits.ItemKit;
-import tc.oc.pgm.kits.ItemKitApplicator;
+import tc.oc.pgm.kits.KitNode;
+import tc.oc.pgm.kits.KitPlayerFacet;
+import tc.oc.pgm.kits.RemoveKit;
 import tc.oc.pgm.kits.SlotItemKit;
 import tc.oc.pgm.match.Match;
 import tc.oc.pgm.match.MatchPlayer;
+import tc.oc.pgm.match.MatchScope;
+import tc.oc.pgm.mutation.Mutation;
+import tc.oc.pgm.mutation.MutationMatchModule;
 import tc.oc.pgm.mutation.types.KitMutation;
 
 import java.time.Duration;
+import java.time.Instant;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class ElytraMutation extends KitMutation {
@@ -30,13 +44,57 @@ public class ElytraMutation extends KitMutation {
 
     @Override
     public void remove(MatchPlayer player) {
-        // If the player is mid-air, give them a totem so they don't fall and die
-        if(player.getBukkit().isGliding()) {
-            ItemKitApplicator applicator = new ItemKitApplicator();
-            applicator.put(Slot.OffHand.offHand(), item(Material.TOTEM), false);
-            applicator.apply(player);
+        // Anyone left gliding will be taken care of by the ground stop order
+        if(!player.getBukkit().isGliding()) {
+            super.remove(player);
         }
-        super.remove(player);
+    }
+
+    @Override
+    public void disable() {
+        new GroundStop(match()).run();
+        super.disable();
+    }
+
+    /**
+     * A cleanup task to slowly remove elytras from players.
+     *
+     * This prevents players that are mid-glide from falling
+     * out of the sky and gives them time to land.
+     */
+    private class GroundStop implements Runnable {
+
+        Match match;
+        WeakHashSet<MatchPlayer> gliding;
+        Instant end;
+
+        GroundStop(Match match) {
+            this.match = match;
+            this.gliding = new WeakHashSet<>(match.participants().filter(player -> player.getBukkit().isGliding()).collect(Collectors.toSet()));
+            this.end = match.getInstantNow().plus(Duration.ofSeconds(10));
+        }
+
+        @Override
+        public void run() {
+            if(match.isRunning() && !gliding.isEmpty() && !match.module(MutationMatchModule.class).get().enabled(Mutation.ELYTRA)) {
+                Instant now = match().getInstantNow();
+                for(MatchPlayer player : ImmutableSet.copyOf(gliding)) {
+                    if(!player.isSpawned() || !player.getBukkit().isGliding() || TimeUtils.isEqualOrBeforeNow(now, end)) {
+                        gliding.remove(player);
+                        player.facet(KitPlayerFacet.class).applyKit(KitNode.of(new RemoveKit(ELYTRA), new RemoveKit(JUMP)), true);
+                        player.sendHotbarMessage(Components.blank());
+                    } else {
+                        long seconds = Duration.between(now, end).getSeconds();
+                        player.sendHotbarMessage(new WarningComponent("mutation.type.elytra.land", new Component(seconds, ChatColor.YELLOW)));
+                    }
+                }
+                match.getScheduler(MatchScope.RUNNING).createDelayedTask(Duration.ofMillis(50), this::run);
+            } else {
+                gliding.clear();
+                match = null;
+            }
+        }
+
     }
 
 }

--- a/PGM/src/main/java/tc/oc/pgm/mutation/types/kit/EnchantmentMutation.java
+++ b/PGM/src/main/java/tc/oc/pgm/mutation/types/kit/EnchantmentMutation.java
@@ -21,31 +21,28 @@ import java.util.WeakHashMap;
 public class EnchantmentMutation extends KitMutation {
 
     final static ImmutableMap<Integer, Integer> LEVELS_MAP = new ImmutableMap.Builder<Integer, Integer>()
-            .put(1, 10)
-            .put(2, 3)
+            .put(1, 25)
+            .put(2, 5)
             .put(3, 1)
             .build();
 
     final static ImmutableMap<Enchantment, Integer> ARMOR_MAP = new ImmutableMap.Builder<Enchantment, Integer>()
             .put(Enchantment.PROTECTION_ENVIRONMENTAL, 15)
             .put(Enchantment.PROTECTION_PROJECTILE,    10)
-            .put(Enchantment.DURABILITY,               10)
             .put(Enchantment.PROTECTION_EXPLOSIONS,    5)
-            .put(Enchantment.PROTECTION_FALL,          5)
             .put(Enchantment.PROTECTION_FIRE,          5)
             .put(Enchantment.THORNS,                   1)
             .build();
 
     final static ImmutableMap<Enchantment, Integer> BOOTS_MAP = new ImmutableMap.Builder<Enchantment, Integer>()
             .putAll(ARMOR_MAP)
-            .put(Enchantment.WATER_WORKER,  5)
-            .put(Enchantment.DEPTH_STRIDER, 3)
-            .put(Enchantment.FROST_WALKER,  1)
+            .put(Enchantment.PROTECTION_FALL, 10)
+            .put(Enchantment.DEPTH_STRIDER,   3)
+            .put(Enchantment.FROST_WALKER,    1)
             .build();
 
     final static ImmutableMap<Enchantment, Integer> WEAPONS_MAP = new ImmutableMap.Builder<Enchantment, Integer>()
             .put(Enchantment.DAMAGE_ALL,    15)
-            .put(Enchantment.DURABILITY,    10)
             .put(Enchantment.KNOCKBACK,     10)
             .put(Enchantment.MENDING,       5)
             .put(Enchantment.SWEEPING_EDGE, 5)
@@ -53,7 +50,6 @@ public class EnchantmentMutation extends KitMutation {
             .build();
 
     final static ImmutableMap<Enchantment, Integer> TOOLS_MAP = new ImmutableMap.Builder<Enchantment, Integer>()
-            .put(Enchantment.DURABILITY,        10)
             .put(Enchantment.DIG_SPEED,         10)
             .put(Enchantment.SILK_TOUCH,        5)
             .put(Enchantment.LOOT_BONUS_BLOCKS, 5)
@@ -116,9 +112,9 @@ public class EnchantmentMutation extends KitMutation {
             byEntity.put(item, ImmutableMap.copyOf(item.getEnchantments()));
             savedEnchantments.put(entity, byEntity);
             // Apply the new enchantments
-            int amountOfEnchants = LEVELS.choose(entropy);
+            int amountOfEnchants = LEVELS.choose(entropy());
             for(int i = 0; i < amountOfEnchants; i++) {
-                item.addUnsafeEnchantment(chooser.choose(entropy), LEVELS.choose(entropy));
+                item.addUnsafeEnchantment(chooser.choose(entropy()), LEVELS.choose(entropy()));
             }
 
         }
@@ -129,7 +125,7 @@ public class EnchantmentMutation extends KitMutation {
         super.apply(player);
         player.getInventory().forEach(item -> {
             // Random number of enchantments on each item
-            int numberOfEnchants = LEVELS.choose(entropy);
+            int numberOfEnchants = LEVELS.choose(entropy());
             for(int i = 0; i < numberOfEnchants; i++) {
                 apply(item, player.getBukkit().getEquipment());
             }

--- a/PGM/src/main/java/tc/oc/pgm/mutation/types/kit/EquestrianMutation.java
+++ b/PGM/src/main/java/tc/oc/pgm/mutation/types/kit/EquestrianMutation.java
@@ -4,12 +4,11 @@ import com.google.common.collect.ImmutableMap;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.AbstractHorse;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Horse;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
-import org.bukkit.event.player.PlayerSpawnEntityEvent;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.inventory.HorseInventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SpawnEggMeta;
@@ -17,23 +16,23 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import tc.oc.commons.core.random.ImmutableWeightedRandomChooser;
 import tc.oc.commons.core.random.WeightedRandomChooser;
-import tc.oc.pgm.events.MatchPlayerDeathEvent;
-import tc.oc.pgm.events.PlayerChangePartyEvent;
 import tc.oc.pgm.kits.FreeItemKit;
 import tc.oc.pgm.kits.Kit;
 import tc.oc.pgm.match.Match;
 import tc.oc.pgm.match.MatchPlayer;
-import tc.oc.pgm.mutation.types.KitMutation;
+import tc.oc.pgm.mutation.types.EntityMutation;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Map;
-import java.util.WeakHashMap;
 
-public class EquestrianMutation extends KitMutation {
+import static tc.oc.commons.core.util.Optionals.cast;
+
+public class EquestrianMutation extends EntityMutation<AbstractHorse> {
 
     final static ImmutableMap<EntityType, Integer> TYPE_MAP = new ImmutableMap.Builder<EntityType, Integer>()
             .put(EntityType.HORSE,          100)
-            // FIXME: Saddle do not work on these horses
+            // FIXME: Saddles do not work on these horses
             //.put(EntityType.SKELETON_HORSE, 5)
             //.put(EntityType.ZOMBIE_HORSE,   5)
             //.put(EntityType.LLAMA,          1)
@@ -49,18 +48,15 @@ public class EquestrianMutation extends KitMutation {
     final static WeightedRandomChooser<EntityType, Integer> TYPES = new ImmutableWeightedRandomChooser<>(TYPE_MAP);
     final static WeightedRandomChooser<Material, Integer> ARMOR = new ImmutableWeightedRandomChooser<>(ARMOR_MAP);
 
-    final Map<MatchPlayer, AbstractHorse> horses;
-
     public EquestrianMutation(Match match) {
         super(match, false);
-        this.horses = new WeakHashMap<>();
     }
 
     @Override
-    public void disable() {
-        super.disable();
-        match.participants().forEach(this::remove);
-        horses.clear();
+    public void enable() {
+        super.enable();
+        this.itemRemove.add(Material.LEATHER);
+        this.itemRemove.addAll(ARMOR_MAP.keySet());
     }
 
     @Override
@@ -72,7 +68,7 @@ public class EquestrianMutation extends KitMutation {
         if(!spawnable(location)) {
             ItemStack item = item(Material.MONSTER_EGG);
             SpawnEggMeta egg = (SpawnEggMeta) item.getItemMeta();
-            egg.setSpawnedType(TYPES.choose(entropy));
+            egg.setSpawnedType(TYPES.choose(entropy()));
             item.setItemMeta(egg);
             kits.add(new FreeItemKit(item));
         }
@@ -83,38 +79,31 @@ public class EquestrianMutation extends KitMutation {
         super.apply(player);
         Location location = player.getLocation();
         if(spawnable(location)) {
-            setup(player, spawn(location, (Class<? extends AbstractHorse>) TYPES.choose(match.entropyForTick()).getEntityClass()));
+            spawn(location, (Class<AbstractHorse>) TYPES.choose(entropy()).getEntityClass(), player);
         }
     }
 
     @Override
-    public void remove(MatchPlayer player) {
-        super.remove(player);
-        AbstractHorse horse = horses.remove(player);
-        if(horse != null) {
-            horse.ejectAll();
-            horse.remove();
+    public AbstractHorse register(AbstractHorse horse, @Nullable MatchPlayer owner) {
+        super.register(horse, owner);
+        if(owner != null) {
+            horse.setAdult();
+            horse.setJumpStrength(2 * entropy().randomDouble());
+            horse.setDomestication(1);
+            horse.setMaxDomestication(1);
+            horse.setTamed(true);
+            horse.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, Integer.MAX_VALUE, 0));
+            horse.setOwner(owner.getBukkit());
+            horse.setPassenger(owner.getBukkit());
+            cast(horse, Horse.class).ifPresent(horsey -> {
+                horsey.setStyle(entropy().randomElement(Horse.Style.values()));
+                horsey.setColor(entropy().randomElement(Horse.Color.values()));
+                HorseInventory inventory = horsey.getInventory();
+                inventory.setSaddle(item(Material.SADDLE));
+                inventory.setArmor(item(ARMOR.choose(entropy())));
+            });
         }
-    }
-
-    public void setup(MatchPlayer player, AbstractHorse horse) {
-        horses.put(player, horse);
-        horse.setAdult();
-        horse.setJumpStrength(2 * entropy.randomDouble());
-        horse.setDomestication(1);
-        horse.setMaxDomestication(1);
-        horse.setTamed(true);
-        horse.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, Integer.MAX_VALUE, 0));
-        horse.setOwner(player.getBukkit());
-        horse.setPassenger(player.getBukkit());
-        if(horse instanceof Horse) {
-            Horse horsey = (Horse) horse;
-            horsey.setStyle(entropy.randomElement(Horse.Style.values()));
-            horsey.setColor(entropy.randomElement(Horse.Color.values()));
-            HorseInventory inventory = horsey.getInventory();
-            inventory.setSaddle(item(Material.SADDLE));
-            inventory.setArmor(item(ARMOR.choose(entropy)));
-        }
+        return horse;
     }
 
     public boolean spawnable(Location location) {
@@ -129,22 +118,11 @@ public class EquestrianMutation extends KitMutation {
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
-    public void onEntitySpawn(PlayerSpawnEntityEvent event) {
-        Entity entity = event.getEntity();
-        if(TYPE_MAP.containsKey(entity.getType())) {
-            match.participant(event.getPlayer())
-                 .ifPresent(player -> setup(player, (AbstractHorse) event.getEntity()));
+    public void onEntityDamage(EntityDamageByEntityEvent event) {
+        if(playerByEntity(event.getEntity()).flatMap(MatchPlayer::competitor)
+                                            .equals(match().participant(event.getDamager()).flatMap(MatchPlayer::competitor))) {
+            event.setCancelled(true);
         }
-    }
-
-    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
-    public void onPlayerDeath(MatchPlayerDeathEvent event) {
-        remove(event.getVictim());
-    }
-
-    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
-    public void onPartyChange(PlayerChangePartyEvent event) {
-        remove(event.getPlayer());
     }
 
 }

--- a/PGM/src/main/java/tc/oc/pgm/mutation/types/kit/ExplosiveMutation.java
+++ b/PGM/src/main/java/tc/oc/pgm/mutation/types/kit/ExplosiveMutation.java
@@ -3,13 +3,11 @@ package tc.oc.pgm.mutation.types.kit;
 import com.google.common.collect.Range;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
-import org.bukkit.entity.TNTPrimed;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.ExplosionPrimeEvent;
 import org.bukkit.inventory.PlayerInventory;
 import tc.oc.commons.bukkit.item.ItemBuilder;
-import tc.oc.commons.core.collection.WeakHashSet;
 import tc.oc.pgm.killreward.KillReward;
 import tc.oc.pgm.kits.FreeItemKit;
 import tc.oc.pgm.kits.ItemKit;
@@ -30,26 +28,17 @@ public class ExplosiveMutation extends KitMutation {
 
     final static Range<Integer> RADIUS = Range.openClosed(0, 4);
 
-    final WeakHashSet<TNTPrimed> tracked;
-
     public ExplosiveMutation(Match match) {
         super(match, false);
-        this.tracked = new WeakHashSet<>();
         this.rewards.add(new KillReward(TNT));
         this.rewards.add(new KillReward(ARROWS));
-    }
-
-    @Override
-    public void disable() {
-        super.disable();
-        tracked.clear();
     }
 
     @Override
     public void kits(MatchPlayer player, List<Kit> kits) {
         super.kits(player, kits);
         PlayerInventory inv = player.getInventory();
-        if(random.nextBoolean()) { // tnt and lighter kit
+        if(random().nextBoolean()) { // tnt and lighter kit
             if(!inv.contains(Material.TNT)) kits.add(TNT);
             if(!inv.contains(Material.FLINT_AND_STEEL)) kits.add(LIGHTER);
         } else { // fire bow and arrows kit
@@ -62,9 +51,15 @@ public class ExplosiveMutation extends KitMutation {
         }
     }
 
+    @Override
+    public void remove(MatchPlayer player) {
+        player.getInventory().all(Material.BOW).values().forEach(bow -> FIRE_BOW.item().getEnchantments().keySet().forEach(enchantment -> bow.removeEnchantment(enchantment)));
+        super.remove(player);
+    }
+
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
     public void onExplosionPrime(ExplosionPrimeEvent event) {
-        event.setRadius(event.getRadius() + entropy.randomInt(RADIUS));
+        event.setRadius(event.getRadius() + entropy().randomInt(RADIUS));
     }
 
 }

--- a/PGM/src/main/java/tc/oc/pgm/mutation/types/kit/HardcoreMutation.java
+++ b/PGM/src/main/java/tc/oc/pgm/mutation/types/kit/HardcoreMutation.java
@@ -1,7 +1,6 @@
 package tc.oc.pgm.mutation.types.kit;
 
 import org.bukkit.Material;
-import org.bukkit.inventory.ItemStack;
 import tc.oc.pgm.gamerules.GameRulesMatchModule;
 import tc.oc.pgm.killreward.KillReward;
 import tc.oc.pgm.kits.FreeItemKit;
@@ -26,13 +25,13 @@ public class HardcoreMutation extends KitMutation {
     }
 
     public GameRulesMatchModule rules() {
-        return match.module(GameRulesMatchModule.class).get();
+        return match().module(GameRulesMatchModule.class).get();
     }
 
     @Override
     public void enable() {
         super.enable();
-        previous = world.getGameRuleValue(KEY);
+        previous = world().getGameRuleValue(KEY);
         rules().gameRules().put(KEY, "false");
     }
 
@@ -40,7 +39,7 @@ public class HardcoreMutation extends KitMutation {
     public void disable() {
         rules().gameRules().remove(KEY);
         if(previous != null) {
-            world.setGameRuleValue(KEY, previous);
+            world().setGameRuleValue(KEY, previous);
         }
         super.disable();
     }

--- a/PGM/src/main/java/tc/oc/pgm/mutation/types/kit/HealthMutation.java
+++ b/PGM/src/main/java/tc/oc/pgm/mutation/types/kit/HealthMutation.java
@@ -1,7 +1,6 @@
 package tc.oc.pgm.mutation.types.kit;
 
 import org.bukkit.Material;
-import org.bukkit.inventory.ItemStack;
 import tc.oc.pgm.killreward.KillReward;
 import tc.oc.pgm.kits.FreeItemKit;
 import tc.oc.pgm.kits.HealthKit;

--- a/PGM/src/main/java/tc/oc/pgm/mutation/types/kit/MobsMutation.java
+++ b/PGM/src/main/java/tc/oc/pgm/mutation/types/kit/MobsMutation.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Range;
 import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SpawnEggMeta;
 import tc.oc.commons.core.random.ImmutableWeightedRandomChooser;
@@ -12,11 +13,11 @@ import tc.oc.pgm.kits.FreeItemKit;
 import tc.oc.pgm.kits.Kit;
 import tc.oc.pgm.match.Match;
 import tc.oc.pgm.match.MatchPlayer;
-import tc.oc.pgm.mutation.types.KitMutation;
+import tc.oc.pgm.mutation.types.EntityMutation;
 
 import java.util.List;
 
-public class MobsMutation extends KitMutation {
+public class MobsMutation extends EntityMutation<LivingEntity> {
 
     final static ImmutableMap<EntityType, Integer> TYPE_MAP = new ImmutableMap.Builder<EntityType, Integer>()
             .put(EntityType.ZOMBIE,          50)
@@ -37,17 +38,17 @@ public class MobsMutation extends KitMutation {
     final static Range<Integer> AMOUNT = Range.closed(1, 3);
 
     public MobsMutation(Match match) {
-        super(match, true);
+        super(match, false);
     }
 
     @Override
     public void kits(MatchPlayer player, List<Kit> kits) {
         super.kits(player, kits);
-        int eggs = entropy.randomInt(AMOUNT);
+        int eggs = entropy().randomInt(AMOUNT);
         for(int i = 0; i < eggs; i++) {
-            ItemStack item = item(Material.MONSTER_EGG, entropy.randomInt(AMOUNT));
+            ItemStack item = item(Material.MONSTER_EGG, entropy().randomInt(AMOUNT));
             SpawnEggMeta egg = (SpawnEggMeta) item.getItemMeta();
-            egg.setSpawnedType(TYPES.choose(entropy));
+            egg.setSpawnedType(TYPES.choose(entropy()));
             item.setItemMeta(egg);
             kits.add(new FreeItemKit(item));
         }

--- a/PGM/src/main/java/tc/oc/pgm/mutation/types/kit/NoFallMutation.java
+++ b/PGM/src/main/java/tc/oc/pgm/mutation/types/kit/NoFallMutation.java
@@ -22,7 +22,7 @@ public abstract class NoFallMutation extends KitMutation {
     }
 
     public DisableDamageMatchModule damage() {
-        return match.module(DisableDamageMatchModule.class).get();
+        return match().module(DisableDamageMatchModule.class).get();
     }
 
     @Override

--- a/PGM/src/main/java/tc/oc/pgm/mutation/types/kit/PotionMutation.java
+++ b/PGM/src/main/java/tc/oc/pgm/mutation/types/kit/PotionMutation.java
@@ -68,13 +68,13 @@ public class PotionMutation extends KitMutation {
     @Override
     public void kits(MatchPlayer player, List<Kit> kits) {
         super.kits(player, kits);
-        int numberOfPotions = entropy.randomInt(AMOUNT_RANGE);
+        int numberOfPotions = entropy().randomInt(AMOUNT_RANGE);
         for(int i = 0; i < numberOfPotions; i++) {
             WeightedRandomChooser<PotionEffectType, Integer> type;
             WeightedRandomChooser<Material, Integer> material;
             Range<Integer> range;
             // Determine whether the potion will be "good" or "bad"
-            if(random.nextBoolean()) {
+            if(random().nextBoolean()) {
                 type = BAD;
                 material = BAD_BOTTLE;
                 range = BAD_DURATION_RANGE;
@@ -84,10 +84,10 @@ public class PotionMutation extends KitMutation {
                 range = GOOD_DURATION_RANGE;
             }
             // Choose all the random attributes
-            PotionEffectType effect = type.choose(entropy);
-            Material bottle = material.choose(entropy);
-            int duration = 20 * entropy.randomInt(range);
-            int amplifier = entropy.randomInt(AMPLIFIER_RANGE);
+            PotionEffectType effect = type.choose(entropy());
+            Material bottle = material.choose(entropy());
+            int duration = 20 * entropy().randomInt(range);
+            int amplifier = entropy().randomInt(AMPLIFIER_RANGE);
             // Apply the attributes to the item stack
             ItemStack potion = item(bottle);
             PotionMeta meta = (PotionMeta) potion.getItemMeta();

--- a/PGM/src/main/java/tc/oc/pgm/mutation/types/other/BlitzMutation.java
+++ b/PGM/src/main/java/tc/oc/pgm/mutation/types/other/BlitzMutation.java
@@ -11,7 +11,7 @@ import tc.oc.pgm.match.MatchScope;
 import tc.oc.pgm.mutation.types.MutationModule;
 import tc.oc.pgm.teams.TeamMatchModule;
 
-public class BlitzMutation extends MutationModule {
+public class BlitzMutation extends MutationModule.Impl {
 
     final static Range<Integer> LIVES = Range.closed(1, 3);
     final static Fraction TEAM_CHANCE = Fraction.ONE_QUARTER;
@@ -23,22 +23,22 @@ public class BlitzMutation extends MutationModule {
     @Override
     public void enable() {
         super.enable();
-        int lives = match.entropyForTick().randomInt(LIVES);
+        int lives = entropy().randomInt(LIVES);
         Lives.Type type;
-        if(match.module(TeamMatchModule.class).isPresent() && RandomUtils.nextBoolean(random, TEAM_CHANCE)) {
+        if(match().module(TeamMatchModule.class).isPresent() && RandomUtils.nextBoolean(random(), TEAM_CHANCE)) {
             type = Lives.Type.TEAM;
-            lives *= match.module(TeamMatchModule.class).get().getFullestTeam().getSize();
+            lives *= match().module(TeamMatchModule.class).get().getFullestTeam().getSize();
         } else {
             type = Lives.Type.INDIVIDUAL;
         }
-        match.module(BlitzMatchModuleImpl.class).get().activate(BlitzProperties.create(match, lives, type));
+        match().module(BlitzMatchModuleImpl.class).get().activate(BlitzProperties.create(match(), lives, type));
     }
 
     @Override
     public void disable() {
-        match.getScheduler(MatchScope.LOADED).createTask(() -> {
-            if(!match.isFinished()) {
-                match.module(BlitzMatchModuleImpl.class).get().deactivate();
+        match().getScheduler(MatchScope.LOADED).createTask(() -> {
+            if(!match().isFinished()) {
+                match().module(BlitzMatchModuleImpl.class).get().deactivate();
             }
         });
         super.disable();

--- a/PGM/src/main/java/tc/oc/pgm/mutation/types/other/RageMutation.java
+++ b/PGM/src/main/java/tc/oc/pgm/mutation/types/other/RageMutation.java
@@ -7,7 +7,7 @@ import tc.oc.pgm.match.Match;
 import tc.oc.pgm.mutation.types.MutationModule;
 import tc.oc.pgm.rage.RageMatchModule;
 
-public class RageMutation extends MutationModule {
+public class RageMutation extends MutationModule.Impl {
 
     RageMatchModule rage;
 
@@ -26,4 +26,5 @@ public class RageMutation extends MutationModule {
         super.disable();
         rage = null;
     }
+
 }

--- a/PGM/src/main/java/tc/oc/pgm/mutation/types/targetable/LightningMutation.java
+++ b/PGM/src/main/java/tc/oc/pgm/mutation/types/targetable/LightningMutation.java
@@ -2,7 +2,6 @@ package tc.oc.pgm.mutation.types.targetable;
 
 import com.google.common.collect.Range;
 import org.bukkit.Location;
-import org.bukkit.World;
 import org.bukkit.util.Vector;
 import tc.oc.pgm.match.Match;
 import tc.oc.pgm.match.MatchPlayer;
@@ -11,32 +10,31 @@ import tc.oc.pgm.mutation.types.TargetMutation;
 import java.time.Duration;
 import java.util.List;
 
-public class LightningMutation extends TargetMutation {
+public class LightningMutation extends TargetMutation.Impl {
 
     final static Duration FREQUENCY = Duration.ofSeconds(30);
-    final static Range<Integer> TARGETS = Range.closed(1, 5);
-    final static Range<Integer> STRIKES = Range.closed(0, 3);
+    final static Range<Integer> TARGETS = Range.closed(2, 5);
+    final static Range<Integer> STRIKES = Range.closed(1, 3);
 
     public LightningMutation(Match match) {
         super(match, FREQUENCY);
     }
 
     @Override
-    public void execute(List<MatchPlayer> players) {
+    public void target(List<MatchPlayer> players) {
         players.forEach(player -> {
-            World world = match.getWorld();
             Location location = player.getLocation();
-            world.strikeLightning(location.clone().add(Vector.getRandom()));
-            int strikes = match.entropyForTick().randomInt(STRIKES);
+            world().strikeLightning(location.clone().add(Vector.getRandom()));
+            int strikes = entropy().randomInt(STRIKES);
             for(int i = 0; i < strikes; i++) {
-                world.strikeLightningEffect(location.clone().add(Vector.getRandom().multiply(Math.pow(i + 1, 2))));
+                world().strikeLightningEffect(location.clone().add(Vector.getRandom().multiply(Math.pow(i + 1, 2))));
             }
         });
     }
 
     @Override
     public int targets() {
-        return match.entropyForTick().randomInt(TARGETS);
+        return match().entropyForTick().randomInt(TARGETS);
     }
 
 }


### PR DESCRIPTION
- `EntityMutation` handles mutations that spawn entities
- Convert `MutationModule` and some other subclasses to interfaces
- Fix players with elytras falling out of the sky on disable
- Fix falling tnt from never exploding
- Fix projectile module giving no kill credit
- Allow `KitMutation` to have a list of material on item remove
- Prevent team killing horses
- Fix team blitz lives not showing updates
- Fix mobs not despawning after disable 